### PR TITLE
Promote from BLAIS5-3240-read-tcp-error to main

### DIFF
--- a/pkg/encryption/pgp_encrypt.go
+++ b/pkg/encryption/pgp_encrypt.go
@@ -71,11 +71,14 @@ func (s service) EncryptFile(encryptRequest models.Encrypt) error {
 func encrypt(recip []*openpgp.Entity, signer *openpgp.Entity, r io.Reader, w io.Writer) error {
 	wc, err := openpgp.Encrypt(w, recip, signer, &openpgp.FileHints{IsBinary: true}, nil)
 	if err != nil {
+        log.Err(err).Msgf("failed to set up encryption: '%s'", err)
 		return err
 	}
 
 	defer wc.Close()
 	if _, err := io.Copy(wc, r); err != nil {
+        log.Err(err).Msgf("failed to fetch content and encrypt: '%s'", err)
+        log.Info().Msg("updating the Go version could fix tcp errors according to https://github.com/googleapis/google-cloud-go/issues/1253 and https://cloud.google.com/functions/docs/concepts/go-runtime")
 		return err
 	}
 


### PR DESCRIPTION
Auto generated by concourse:

Promote from BLAIS5-3240-read-tcp-error to main